### PR TITLE
Change: Remove `v` prefix from docker tags

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -79,7 +79,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-1-6
+      id: prep-3-1-6
       run: |
         set -e
 
@@ -92,7 +92,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.1.6"
+        VARIANT="3.1.6"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -102,45 +102,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.1.6 - Build (PRs)
+    - name: 3.1.6 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.6
+        context: variants/3.1.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-6.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.1.6 - Build and push (master)
+    - name: 3.1.6 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.6
+        context: variants/3.1.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-6.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.1.6 - Build and push (release)
+    - name: 3.1.6 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.6
+        context: variants/3.1.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-6.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-6.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-6.outputs.REF_SHA_VARIANT }}
           ${{ github.repository }}:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
@@ -199,7 +199,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-1-5
+      id: prep-3-1-5
       run: |
         set -e
 
@@ -212,7 +212,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.1.5"
+        VARIANT="3.1.5"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -222,45 +222,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.1.5 - Build (PRs)
+    - name: 3.1.5 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.5
+        context: variants/3.1.5
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-5.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-5.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-5.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-5.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.1.5 - Build and push (master)
+    - name: 3.1.5 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.5
+        context: variants/3.1.5
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-5.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-5.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-5.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-5.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.1.5 - Build and push (release)
+    - name: 3.1.5 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.5
+        context: variants/3.1.5
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-5.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-5.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-5.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-5.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-5.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-5.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -318,7 +318,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-1-4
+      id: prep-3-1-4
       run: |
         set -e
 
@@ -331,7 +331,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.1.4"
+        VARIANT="3.1.4"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -341,45 +341,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.1.4 - Build (PRs)
+    - name: 3.1.4 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.4
+        context: variants/3.1.4
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-4.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-4.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-4.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-4.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.1.4 - Build and push (master)
+    - name: 3.1.4 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.4
+        context: variants/3.1.4
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-4.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-4.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-4.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-4.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.1.4 - Build and push (release)
+    - name: 3.1.4 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.4
+        context: variants/3.1.4
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-4.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-4.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-4.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-4.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-4.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-4.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -437,7 +437,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-1-3
+      id: prep-3-1-3
       run: |
         set -e
 
@@ -450,7 +450,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.1.3"
+        VARIANT="3.1.3"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -460,45 +460,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.1.3 - Build (PRs)
+    - name: 3.1.3 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.3
+        context: variants/3.1.3
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-3.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-3.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-3.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.1.3 - Build and push (master)
+    - name: 3.1.3 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.3
+        context: variants/3.1.3
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-3.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-3.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-3.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.1.3 - Build and push (release)
+    - name: 3.1.3 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.3
+        context: variants/3.1.3
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-3.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-3.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-3.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-3.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-3.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -556,7 +556,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-1-2
+      id: prep-3-1-2
       run: |
         set -e
 
@@ -569,7 +569,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.1.2"
+        VARIANT="3.1.2"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -579,45 +579,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.1.2 - Build (PRs)
+    - name: 3.1.2 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.2
+        context: variants/3.1.2
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-2.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-2.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-2.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-2.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.1.2 - Build and push (master)
+    - name: 3.1.2 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.2
+        context: variants/3.1.2
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-2.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-2.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-2.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-2.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.1.2 - Build and push (release)
+    - name: 3.1.2 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.2
+        context: variants/3.1.2
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-2.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-2.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-2.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-2.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-2.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-2.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -675,7 +675,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-1-1
+      id: prep-3-1-1
       run: |
         set -e
 
@@ -688,7 +688,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.1.1"
+        VARIANT="3.1.1"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -698,45 +698,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.1.1 - Build (PRs)
+    - name: 3.1.1 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.1
+        context: variants/3.1.1
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-1.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-1.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.1.1 - Build and push (master)
+    - name: 3.1.1 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.1
+        context: variants/3.1.1
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-1.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-1.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.1.1 - Build and push (release)
+    - name: 3.1.1 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.1
+        context: variants/3.1.1
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-1.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-1.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-1.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-1.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -794,7 +794,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-1-0
+      id: prep-3-1-0
       run: |
         set -e
 
@@ -807,7 +807,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.1.0"
+        VARIANT="3.1.0"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -817,45 +817,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.1.0 - Build (PRs)
+    - name: 3.1.0 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.0
+        context: variants/3.1.0
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-0.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-0.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.1.0 - Build and push (master)
+    - name: 3.1.0 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.0
+        context: variants/3.1.0
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-0.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-0.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.1.0 - Build and push (release)
+    - name: 3.1.0 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.1.0
+        context: variants/3.1.0
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-1-0.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-0.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-1-0.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-0.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-0.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-1-0.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -913,7 +913,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-0-9
+      id: prep-3-0-9
       run: |
         set -e
 
@@ -926,7 +926,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.0.9"
+        VARIANT="3.0.9"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -936,45 +936,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.0.9 - Build (PRs)
+    - name: 3.0.9 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.9
+        context: variants/3.0.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.9 - Build and push (master)
+    - name: 3.0.9 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.9
+        context: variants/3.0.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.9 - Build and push (release)
+    - name: 3.0.9 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.9
+        context: variants/3.0.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-9.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-9.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1032,7 +1032,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-0-8
+      id: prep-3-0-8
       run: |
         set -e
 
@@ -1045,7 +1045,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.0.8"
+        VARIANT="3.0.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1055,45 +1055,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.0.8 - Build (PRs)
+    - name: 3.0.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.8
+        context: variants/3.0.8
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.8 - Build and push (master)
+    - name: 3.0.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.8
+        context: variants/3.0.8
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.8 - Build and push (release)
+    - name: 3.0.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.8
+        context: variants/3.0.8
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-8.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1151,7 +1151,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-0-7
+      id: prep-3-0-7
       run: |
         set -e
 
@@ -1164,7 +1164,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.0.7"
+        VARIANT="3.0.7"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1174,45 +1174,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.0.7 - Build (PRs)
+    - name: 3.0.7 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.7
+        context: variants/3.0.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.7 - Build and push (master)
+    - name: 3.0.7 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.7
+        context: variants/3.0.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.7 - Build and push (release)
+    - name: 3.0.7 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.7
+        context: variants/3.0.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-7.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-7.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1270,7 +1270,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-0-6
+      id: prep-3-0-6
       run: |
         set -e
 
@@ -1283,7 +1283,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.0.6"
+        VARIANT="3.0.6"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1293,45 +1293,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.0.6 - Build (PRs)
+    - name: 3.0.6 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.6
+        context: variants/3.0.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-6.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.6 - Build and push (master)
+    - name: 3.0.6 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.6
+        context: variants/3.0.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-6.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.6 - Build and push (release)
+    - name: 3.0.6 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.6
+        context: variants/3.0.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-6.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-6.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-6.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1389,7 +1389,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-0-5
+      id: prep-3-0-5
       run: |
         set -e
 
@@ -1402,7 +1402,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.0.5"
+        VARIANT="3.0.5"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1412,45 +1412,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.0.5 - Build (PRs)
+    - name: 3.0.5 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.5
+        context: variants/3.0.5
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-5.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-5.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-5.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-5.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.5 - Build and push (master)
+    - name: 3.0.5 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.5
+        context: variants/3.0.5
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-5.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-5.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-5.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-5.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.5 - Build and push (release)
+    - name: 3.0.5 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.5
+        context: variants/3.0.5
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-5.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-5.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-5.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-5.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-5.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-5.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1508,7 +1508,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-0-4
+      id: prep-3-0-4
       run: |
         set -e
 
@@ -1521,7 +1521,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.0.4"
+        VARIANT="3.0.4"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1531,45 +1531,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.0.4 - Build (PRs)
+    - name: 3.0.4 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.4
+        context: variants/3.0.4
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-4.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-4.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-4.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-4.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.4 - Build and push (master)
+    - name: 3.0.4 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.4
+        context: variants/3.0.4
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-4.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-4.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-4.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-4.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.4 - Build and push (release)
+    - name: 3.0.4 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.4
+        context: variants/3.0.4
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-4.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-4.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-4.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-4.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-4.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-4.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1627,7 +1627,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-0-3
+      id: prep-3-0-3
       run: |
         set -e
 
@@ -1640,7 +1640,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.0.3"
+        VARIANT="3.0.3"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1650,45 +1650,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.0.3 - Build (PRs)
+    - name: 3.0.3 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.3
+        context: variants/3.0.3
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-3.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-3.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-3.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.3 - Build and push (master)
+    - name: 3.0.3 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.3
+        context: variants/3.0.3
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-3.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-3.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-3.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.3 - Build and push (release)
+    - name: 3.0.3 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.3
+        context: variants/3.0.3
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-3.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-3.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-3.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-3.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-3.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1746,7 +1746,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-0-2
+      id: prep-3-0-2
       run: |
         set -e
 
@@ -1759,7 +1759,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.0.2"
+        VARIANT="3.0.2"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1769,45 +1769,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.0.2 - Build (PRs)
+    - name: 3.0.2 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.2
+        context: variants/3.0.2
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-2.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-2.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-2.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-2.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.2 - Build and push (master)
+    - name: 3.0.2 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.2
+        context: variants/3.0.2
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-2.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-2.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-2.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-2.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.2 - Build and push (release)
+    - name: 3.0.2 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.2
+        context: variants/3.0.2
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-2.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-2.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-2.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-2.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-2.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-2.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1865,7 +1865,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v3-0-1
+      id: prep-3-0-1
       run: |
         set -e
 
@@ -1878,7 +1878,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v3.0.1"
+        VARIANT="3.0.1"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1888,45 +1888,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v3.0.1 - Build (PRs)
+    - name: 3.0.1 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.1
+        context: variants/3.0.1
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-1.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-1.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.1 - Build and push (master)
+    - name: 3.0.1 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.1
+        context: variants/3.0.1
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-1.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-1.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v3.0.1 - Build and push (release)
+    - name: 3.0.1 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v3.0.1
+        context: variants/3.0.1
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v3-0-1.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-1.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v3-0-1.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-1.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-1.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-3-0-1.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 

--- a/README.md
+++ b/README.md
@@ -12,22 +12,22 @@ The base image is `alpine`.
 
 | Tag | Dockerfile Build Context |
 |:-------:|:---------:|
-| `:v3.1.6`, `:latest` | [View](variants/v3.1.6) |
-| `:v3.1.5` | [View](variants/v3.1.5) |
-| `:v3.1.4` | [View](variants/v3.1.4) |
-| `:v3.1.3` | [View](variants/v3.1.3) |
-| `:v3.1.2` | [View](variants/v3.1.2) |
-| `:v3.1.1` | [View](variants/v3.1.1) |
-| `:v3.1.0` | [View](variants/v3.1.0) |
-| `:v3.0.9` | [View](variants/v3.0.9) |
-| `:v3.0.8` | [View](variants/v3.0.8) |
-| `:v3.0.7` | [View](variants/v3.0.7) |
-| `:v3.0.6` | [View](variants/v3.0.6) |
-| `:v3.0.5` | [View](variants/v3.0.5) |
-| `:v3.0.4` | [View](variants/v3.0.4) |
-| `:v3.0.3` | [View](variants/v3.0.3) |
-| `:v3.0.2` | [View](variants/v3.0.2) |
-| `:v3.0.1` | [View](variants/v3.0.1) |
+| `:3.1.6`, `:latest` | [View](variants/3.1.6) |
+| `:3.1.5` | [View](variants/3.1.5) |
+| `:3.1.4` | [View](variants/3.1.4) |
+| `:3.1.3` | [View](variants/3.1.3) |
+| `:3.1.2` | [View](variants/3.1.2) |
+| `:3.1.1` | [View](variants/3.1.1) |
+| `:3.1.0` | [View](variants/3.1.0) |
+| `:3.0.9` | [View](variants/3.0.9) |
+| `:3.0.8` | [View](variants/3.0.8) |
+| `:3.0.7` | [View](variants/3.0.7) |
+| `:3.0.6` | [View](variants/3.0.6) |
+| `:3.0.5` | [View](variants/3.0.5) |
+| `:3.0.4` | [View](variants/3.0.4) |
+| `:3.0.3` | [View](variants/3.0.3) |
+| `:3.0.2` | [View](variants/3.0.2) |
+| `:3.0.1` | [View](variants/3.0.1) |
 
 All images are based on Alpine.
 
@@ -37,14 +37,14 @@ In this image, the PKI will be stored in `/data/pki` (i.e. `EASYRSA_PKI=/data/pk
 
 ```sh
 # Generate /data/pki
-docker run --rm -it -v data:/data theohbrothers/docker-easyrsa:v3.1.6 init-pki
+docker run --rm -it -v data:/data theohbrothers/docker-easyrsa:3.1.6 init-pki
 # Generate CA, server and client certs
-docker run --rm -it -e EASYRSA_BATCH=true -v data:/data theohbrothers/docker-easyrsa:v3.1.6 build-ca nopass
-docker run --rm -it -e EASYRSA_BATCH=true -v data:/data theohbrothers/docker-easyrsa:v3.1.6 build-server-full server-01 nopass
-docker run --rm -it -e EASYRSA_BATCH=true -v data:/data theohbrothers/docker-easyrsa:v3.1.6 build-client-full client-01 nopass
+docker run --rm -it -e EASYRSA_BATCH=true -v data:/data theohbrothers/docker-easyrsa:3.1.6 build-ca nopass
+docker run --rm -it -e EASYRSA_BATCH=true -v data:/data theohbrothers/docker-easyrsa:3.1.6 build-server-full server-01 nopass
+docker run --rm -it -e EASYRSA_BATCH=true -v data:/data theohbrothers/docker-easyrsa:3.1.6 build-client-full client-01 nopass
 
 # Alternatively, a nice one liner to do everything
-docker run --rm -it -e EASYRSA_BATCH=true -v data:/data theohbrothers/docker-easyrsa:v3.1.6 sh -c 'set -e; easyrsa init-pki; easyrsa build-ca nopass; easyrsa build-server-full server-01 nopass; easyrsa build-client-full client-01 nopass; find /data/pki'
+docker run --rm -it -e EASYRSA_BATCH=true -v data:/data theohbrothers/docker-easyrsa:3.1.6 sh -c 'set -e; easyrsa init-pki; easyrsa build-ca nopass; easyrsa build-server-full server-01 nopass; easyrsa build-client-full client-01 nopass; find /data/pki'
 ```
 
 According to [`easy-rsa` documentation](https://github.com/OpenVPN/easy-rsa/blob/v3.0.0/doc/EasyRSA-Advanced.md#configuration-reference), there are four ways to run `easy-rsa`, namely:

--- a/Update-Versions.ps1
+++ b/Update-Versions.ps1
@@ -1,4 +1,4 @@
-# This script is to update versions in version.json, create PR(s) for each bumped version, merge PRs, and release
+# This script is to update versions in versions.json, create PR(s) for each bumped version, merge PRs, and release
 # It may be run manually or as a cron
 # Use -WhatIf for dry run
 [CmdletBinding(SupportsShouldProcess)]
@@ -53,4 +53,3 @@ try {
         Pop-Location
     }
 }
-

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -36,9 +36,9 @@ $VARIANTS = @(
                     components = $subVariant['components']
                     job_group_key = $variant['package_version']
                 }
-                # Docker image tag. E.g. 'v3.0.0'
+                # Docker image tag. E.g. '3.0.0'
                 tag = @(
-                        "v$( $variant['package_version'] )"
+                        $variant['package_version']
                         $subVariant['components'] | ? { $_ }
                         # $variant['distro']
                         # $variant['distro_version']

--- a/variants/3.0.1/Dockerfile
+++ b/variants/3.0.1/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/3.0.1/EasyRSA-3.0.1.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.0.1/docker-compose.yml
+++ b/variants/3.0.1/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.0.1
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.0.1/docker-entrypoint.sh
+++ b/variants/3.0.1/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.0.2/Dockerfile
+++ b/variants/3.0.2/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.2/EasyRSA-3.0.2.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.0.2/docker-compose.yml
+++ b/variants/3.0.2/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.0.2
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.0.2/docker-entrypoint.sh
+++ b/variants/3.0.2/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.0.3/Dockerfile
+++ b/variants/3.0.3/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.3/EasyRSA-3.0.3.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.0.3/docker-compose.yml
+++ b/variants/3.0.3/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.0.3
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.0.3/docker-entrypoint.sh
+++ b/variants/3.0.3/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.0.4/Dockerfile
+++ b/variants/3.0.4/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.4/EasyRSA-3.0.4.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.0.4/docker-compose.yml
+++ b/variants/3.0.4/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.0.4
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.0.4/docker-entrypoint.sh
+++ b/variants/3.0.4/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.0.5/Dockerfile
+++ b/variants/3.0.5/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.5/EasyRSA-nix-3.0.5.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.0.5/docker-compose.yml
+++ b/variants/3.0.5/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.0.5
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.0.5/docker-entrypoint.sh
+++ b/variants/3.0.5/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.0.6/Dockerfile
+++ b/variants/3.0.6/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.6/EasyRSA-unix-v3.0.6.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.0.6/docker-compose.yml
+++ b/variants/3.0.6/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.0.6
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.0.6/docker-entrypoint.sh
+++ b/variants/3.0.6/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.0.7/Dockerfile
+++ b/variants/3.0.7/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.7/EasyRSA-3.0.7.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.0.7/docker-compose.yml
+++ b/variants/3.0.7/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.0.7
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.0.7/docker-entrypoint.sh
+++ b/variants/3.0.7/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.0.8/Dockerfile
+++ b/variants/3.0.8/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.8/EasyRSA-3.0.8.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.0.8/docker-compose.yml
+++ b/variants/3.0.8/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.0.8
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.0.8/docker-entrypoint.sh
+++ b/variants/3.0.8/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.0.9/Dockerfile
+++ b/variants/3.0.9/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.9/EasyRSA-v3.0.9.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.0.9/docker-compose.yml
+++ b/variants/3.0.9/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.0.9
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.0.9/docker-entrypoint.sh
+++ b/variants/3.0.9/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.1.0/Dockerfile
+++ b/variants/3.1.0/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.0/EasyRSA-3.1.0.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.1.0/docker-compose.yml
+++ b/variants/3.1.0/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.1.0
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.1.0/docker-entrypoint.sh
+++ b/variants/3.1.0/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.1.1/Dockerfile
+++ b/variants/3.1.1/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.1/EasyRSA-3.1.1.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.1.1/docker-compose.yml
+++ b/variants/3.1.1/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.1.1
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.1.1/docker-entrypoint.sh
+++ b/variants/3.1.1/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.1.2/Dockerfile
+++ b/variants/3.1.2/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.2/EasyRSA-3.1.2.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.1.2/docker-compose.yml
+++ b/variants/3.1.2/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.1.2
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.1.2/docker-entrypoint.sh
+++ b/variants/3.1.2/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.1.3/Dockerfile
+++ b/variants/3.1.3/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.3/EasyRSA-3.1.3.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.1.3/docker-compose.yml
+++ b/variants/3.1.3/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.1.3
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.1.3/docker-entrypoint.sh
+++ b/variants/3.1.3/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.1.4/Dockerfile
+++ b/variants/3.1.4/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.4/EasyRSA-3.1.4.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.1.4/docker-compose.yml
+++ b/variants/3.1.4/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.1.4
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.1.4/docker-entrypoint.sh
+++ b/variants/3.1.4/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.1.5/Dockerfile
+++ b/variants/3.1.5/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.5/EasyRSA-3.1.5.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.1.5/docker-compose.yml
+++ b/variants/3.1.5/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.1.5
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.1.5/docker-entrypoint.sh
+++ b/variants/3.1.5/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"

--- a/variants/3.1.6/Dockerfile
+++ b/variants/3.1.6/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+RUN apk add --no-cache ca-certificates
+
+# Install easyrsa dependencies
+RUN apk add --no-cache openssl
+
+WORKDIR /data
+ENV EASYRSA=/usr/share/easy-rsa
+ENV EASYRSA_PKI=/data/pki
+
+# Install easyrsa
+# See: https://github.com/OpenVPN/easy-rsa/tree/master/release-keys
+RUN set -eux; \
+    apk add --no-cache gnupg gpg-agent dirmngr; \
+    URL=https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.6/EasyRSA-3.1.6.tgz; \
+    FILE=$( basename $URL ); \
+    wget -q "$URL"; \
+    wget -q "$URL.sig"; \
+    gpg --keyserver keys.openpgp.org --recv-keys 6F4056821152F03B6B24F2FCF8489F839D7367F3; \
+    gpg --verify "$FILE.sig" "$FILE"; \
+    mkdir -p /usr/share/easy-rsa; \
+    tar -zxvf "$FILE" --strip-components=1 -C /usr/share/easy-rsa; \
+    ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa; \
+    \
+    easyrsa help; \
+    easyrsa init-pki; \
+    rm -rfv /data/pki; \
+    \
+    rm -fv ""; \
+    rm -fv ".sig"; \
+    apk del gnupg gpg-agent dirmngr; \
+    # Fix error: rm: can't remove '/root/.gnupg/S.gpg-agent.extra': No such file or directory
+    killall dirmngr; \
+    killall gpg-agent; \
+    rm -rf /root/.gnupg;
+
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/variants/3.1.6/docker-compose.yml
+++ b/variants/3.1.6/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2.1'
+services:
+  easyrsa:
+    container_name: easyrsa
+    image: theohbrothers/docker-easyrsa:3.1.6
+
+    # Uncomment and configure these environment to your needs. The following are the default values, according to: https://github.com/OpenVPN/easy-rsa/blob/v3.0.8/doc/EasyRSA-Advanced.md#configuration-reference
+    # Using environment variables is preferred to using a vars file
+    # Double dollar signs '$$' is to escape a dollar sign in the docker-compose yaml parser, see: https://stackoverflow.com/a/40621373
+    # environment:
+      # - EASYRSA_SSL_CONF=/etc/ssl/openssl.cnf
+      # - EASYRSA=$${0%/*}
+      # - EASYRSA_OPENSSL=openssl
+      # - EASYRSA_SSL_CONF=$$EASYRSA/openssl-easyrsa.cnf
+      # - EASYRSA_PKI=$$PWD/pki
+      # - EASYRSA_DN=cn_only
+      # - EASYRSA_REQ_COUNTRY=US
+      # - EASYRSA_REQ_PROVINCE=California
+      # - EASYRSA_REQ_CITY=San Francisco
+      # - EASYRSA_REQ_ORG=Copyleft Certificate Co
+      # - EASYRSA_REQ_EMAIL=me@example.net
+      # - EASYRSA_REQ_OU=My Organizational Unit
+      # - EASYRSA_KEY_SIZE=2048
+      # - EASYRSA_ALGO=rsa
+      # - EASYRSA_CURVE=secp384r1
+      # - EASYRSA_CA_EXPIRE=3650
+      # - EASYRSA_CERT_EXPIRE=180
+      # - EASYRSA_CERT_RENEW=30
+      # - EASYRSA_NS_SUPPORT=no
+      # - EASYRSA_NS_COMMENT=Easy-RSA Generated Certificate
+      # - EASYRSA_TEMP_FILE=$$EASYRSA_PKI/extensions.temp
+      # - EASYRSA_EXT_DIR=$$EASYRSA/x509-types
+      # - EASYRSA_REQ_CN=ChangeMe
+      # - EASYRSA_DIGEST=sha256
+      # - EASYRSA_BATCH=
+
+    # Uncomment this to mount your own openssl.cnf, vars file(s)
+    # volumes:
+      # - ./path/to/openssl.conf:/etc/ssl/openssl.cnf
+      # - ./path/to/vars:/etc/ssl/openssl.cnf

--- a/variants/3.1.6/docker-entrypoint.sh
+++ b/variants/3.1.6/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ]; then
+    # Get all subcommands. 'help' is also a subcommand
+    SUBCOMMANDS=$( easyrsa help | awk "/init-pki/,/^$/" | awk '{print $1}' | awk NF ; echo help )
+    if echo "$SUBCOMMANDS" | grep "^$1$"; then
+        set "easyrsa" "$@"
+        echo "Executing: $@"
+        exec "$@"
+    fi
+else
+    exec "easyrsa" "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Docker image tag conventions are starting to become clear that it is preferred to omit `v` prefix. While having the `v` prefix in the past might have been common, it is becoming less and less common today, with most of docker official images
(https://github.com/docker-library/official-images) omitting the `v` prefix.
